### PR TITLE
Build: Bump to Scala 3.2.0 (and thus Scala.js 1.9.0) to avoid sourcemaps bug

### DIFF
--- a/project/ScalaVersions.scala
+++ b/project/ScalaVersions.scala
@@ -1,5 +1,5 @@
 object ScalaVersions {
   val v213 = "2.13.6"
   val v212 = "2.12.14"
-  val v3   = "3.0.1"
+  val v3   = "3.2.0"
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,6 @@
 logLevel := Level.Warn
 
-val scalajsVersion = scala.sys.env.getOrElse("SCALAJS_VERSION", "1.5.1")
+val scalajsVersion = scala.sys.env.getOrElse("SCALAJS_VERSION", "1.9.0")
 
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % scalajsVersion)
 


### PR DESCRIPTION
This one: https://github.com/lampepfl/dotty/issues/14240

Heyo, as per [todays discussion](https://discord.com/channels/632150470000902164/635668814956068864/1024160318022230088) in scala-js Discord, I need to upgrade all dependencies of Laminar to Scala 3.2.0, which in turn requires upgrading them to Scala.js 1.9.0.

I'm not 100% sure how to set the Scala.js version that Tuplez is published with. I updated the "default" Scala.js version to the new minimum workable one.

Could you please publish this as 0.3.7?